### PR TITLE
修复误引用 torch sqrt 的错误

### DIFF
--- a/model/attention/CoAtNet.py
+++ b/model/attention/CoAtNet.py
@@ -1,4 +1,4 @@
-from torch import nn, sqrt
+from torch import nn
 import torch
 import sys
 from math import sqrt


### PR DESCRIPTION
使用的不是 `torch` 中的 `sqrt`，会被 `from math import sqrt` 覆盖，但是若调整 import 顺序会导致出错。